### PR TITLE
add an API of updating links in batch

### DIFF
--- a/packages/admin-api/src/clients/LinkClient.ts
+++ b/packages/admin-api/src/clients/LinkClient.ts
@@ -37,6 +37,13 @@ export class LinkClient {
     return this.client.put(path, { ...params })
   }
 
+  public updateInBatch(params: Array<Link>): Promise<Response<Array<Link>>> {
+    const path = buildPath({
+      endpointName: 'links/batch',
+    })
+    return this.client.put(path, [...params])
+  }
+
   public async delete(id: number): Promise<void> {
     const path = buildPath({
       endpointName: `links/${id}`,


### PR DESCRIPTION
1. LinkClient#updateInBatch
增加了`updateInBatch()`接口，用来对友链批量更新
---
[halo-dev/halo#1905](https://github.com/halo-dev/halo/issues/1905)

```release-note
None
```